### PR TITLE
upgrade to nom 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 repository = "https://github.com/leeola/mdmatter.rs"
 
 [dependencies]
-nom = "1.2.4"
+nom = "^2.0"
 
 [dev-dependencies]
 stainless = "0.1.6"


### PR DESCRIPTION
Hi!

as a part of the release process for nom 2.0, I selected a few crates to test it with, and make sure everything works correctly.

I'm happy to tell you that this crate built fine with nom 2.0 out of the box, no need to change anything!

If you want more information on this release, see the blogpost: https://unhandledexpression.com/2016/11/25/this-year-in-nom-2-0-is-here/ (reddit discussion: https://www.reddit.com/r/rust/comments/5espfm/this_year_in_nom_20_is_here/ )

There are a few new features that could be of interest for this project :)